### PR TITLE
language, grammar & style edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repo contains a series of python jupyter-notebooks to explain how bitcoin t
 ## Chapters
 
 + Chapter 1: 'Legacy Transactions'
-  - '[The First Bitcoin Transactin (Pay to Pubkey)](https://github.com/DariusParvin/bitcoin-tx-tutorial/blob/main/chapter1-legacy/first-btc-tx.ipynb)'
+  - '[The First Bitcoin Transaction (Pay to Pubkey)](https://github.com/DariusParvin/bitcoin-tx-tutorial/blob/main/chapter1-legacy/first-btc-tx.ipynb)'
   - '[P2PKH - Pay to Pubkey Hash](https://github.com/DariusParvin/bitcoin-tx-tutorial/blob/main/chapter1-legacy/p2pkh.ipynb)'
   - '[P2SH - Pay to Script Hash (2-of-3 Mulitisig)](https://github.com/DariusParvin/bitcoin-tx-tutorial/blob/main/chapter1-legacy/p2sh-multisig.ipynb)'
 + Chapter 2: 'Segwit v0'

--- a/chapter1-legacy/first-btc-tx.ipynb
+++ b/chapter1-legacy/first-btc-tx.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "The first bitcoin transactions created by Satoshi are very different to the typical bitcoin transactions you see on the blockchain today. Over the years there have been a number of upgrades to the bitcoin protocol that have resolved issues such as transaction malleability, and introduced new features such as timelocks and schnorr signatures. \n",
     "\n",
-    "To understand how the various types of bitcoin transactions work, it's helpful to understand how the earliest transaction types worked, and how the new features got intoduced. What may otherwise seem like a strangely written protocol with counterintuitive behaviour begins to make more sense when appreciating that all the upgrades have been implemented in such a way to avoid causing a hardfork. In other words, any valid bitcoin transactions using the newer features must still be valid from the point of view of the earliest bitcoin node versions.\n",
+    "To understand how various types of bitcoin transactions work, it's helpful to understand how the earliest transaction types worked, and how new features got introduced. Taken at face value, the protocol can seem strangely written. The design makes more sense when appreciating that all upgrades have used softforks to enable backwards compatibility.\n",
     "\n",
     "With this view in mind, we'll start by looking at the very first transaction types, then work our way chronologically through the various upgrades to arrive at the latest transaction types and features used today. "
    ]

--- a/chapter1-legacy/first-btc-tx.ipynb
+++ b/chapter1-legacy/first-btc-tx.ipynb
@@ -10,11 +10,11 @@
     "## Introduction\n",
     "Transactions are perhaps the most important part of the bitcoin protocol. All the other aspects of the bitcoin protocol ultimately serve to verify, secure, and agree upon the order of bitcoin transactions. \n",
     "\n",
-    "The first bitcoin transactions created by Satoshi are very different to the typical bitcoin transaction you'd see on the blockchain today. Over the years there have been a number of upgrades to the bitcoin protocol that have resolved issues such as transaction malleability, and introduced new features such as timelocks, and schnorr signatures. \n",
+    "The first bitcoin transactions created by Satoshi are very different to the typical bitcoin transactions you see on the blockchain today. Over the years there have been a number of upgrades to the bitcoin protocol that have resolved issues such as transaction malleability, and introduced new features such as timelocks and schnorr signatures. \n",
     "\n",
     "To understand how the various types of bitcoin transactions work, it's helpful to understand how the earliest transaction types worked, and how the new features got intoduced. What may otherwise seem like a strangely written protocol with counterintuitive behaviour begins to make more sense when appreciating that all the upgrades have been implemented in such a way to avoid causing a hardfork. In other words, any valid bitcoin transactions using the newer features must still be valid from the point of view of the earliest bitcoin node versions.\n",
     "\n",
-    "With this view in mind, we'll start by looking at with the very first transaction types, then work our way chronologically through the various upgrades to arrive at the latest transaction types and features used today. "
+    "With this view in mind, we'll start by looking at the very first transaction types, then work our way chronologically through the various upgrades to arrive at the latest transaction types and features used today. "
    ]
   },
   {
@@ -24,7 +24,7 @@
    "source": [
     "## The first bitcoin transaction\n",
     "\n",
-    "Legacy bitcoin transactions have just four main components: the version, inputs, outputs, and locktime. To illustrate each of these fields and what they do, we'll go through an example using the first ever bitcoin transaction at January 11, 2009 at 7:30 PM PST. It was a transfer of 10 BTC from Satoshi Nakamoto to Hal Finney.\n",
+    "Legacy bitcoin transactions have four main components: the version, inputs, outputs, and locktime. To illustrate each of these fields and what they do, we'll go through an example using the first ever bitcoin transaction. On January 11, 2009 at 7:30 PM PST, Satoshi Nakamoto transfered 10 BTC to Hal Finney.\n",
     "\n",
     "This transaction spent a UTXO that was mined directly by Satoshi, where the block reward was 50 BTC. The transaction had two outputs, one to Hal Finney for 10 BTC, and a change output for 40 BTC.\n",
     "\n",
@@ -43,9 +43,9 @@
     "### Version\n",
     "- `01000000` - Version number (4-byte signed integer, little endian)\n",
     "\n",
-    "The first four bytes of a transaction represents the version number. This number is a way for the transaction to signal what features or consensus rules the transaction may be using. To date, the only feature that uses the version field is relative timelocks (BIP68). What this means is that a relative timelock will only be enforced if the version field is set to 2. We'll demonstrate this in the chapter on relative timelocks.\n",
+    "The first four bytes of a transaction represents the version number. This number is a way for the transaction to signal what features or consensus rules the transaction may be using. To date, the only feature that uses the version field is relative timelocks (BIP68). A relative timelock will only be enforced if the version field is set to 2. We'll demonstrate this in the chapter on relative timelocks.\n",
     "\n",
-    "In the rest of the version numbers may be used to signal new features in the future that don't currently exist."
+    "In the future, version numbers can be used to signal new features that don't currently exist."
    ]
   },
   {
@@ -69,12 +69,13 @@
     "        - `00000000` - Index (4-byte integer)        \n",
     "    The outpoint is the way we can uniquely represent transaction outputs. The txid is computed from the hash over the transaction (more on that below), and the index is the order of the output in that transaction.\n",
     "\n",
-    "    - scriptSig:\n",
+    "    - scriptSig\n",
     "        - `48` - scriptSig length (1-9 byte variable integer)\n",
     "        - `47304402204e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd410220181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d0901` - scriptSig (arbitrary length)   \n",
     "    The scriptSig (aka unlocking script) is what proves ownership of the input. The scriptSig together with the scriptPubkey of the transaction being referenced in the input is valid if nothing in it triggers a failure and the top stack item is non-zero when the script is evaluated. Since the length of the scriptSig will vary depending on the transaction, it id prepended with its length. This lets us know where the scriptSig ends and where the next field begins.\n",
-    "    - `ffffffff` - sequence (4 bytes)  \n",
-    "       In satoshi's initial version of bitcoin the sequence field had no purpose and was intended for future use for something like a payment channel. The solution didn't work however, and since then the field has been repurposed. It has two uses. The first is to signal 'replace by fee' (RBF). Any value less than `0xfffffffe` will signal for RBF. The second is to for use as relative time-lock. For more on this review the chapter on transaction-level and script-level timelocks."
+    "    - sequence \n",
+    "        - `ffffffff` - (4 bytes)  \n",
+    "       In satoshi's initial version of bitcoin, the sequence field had no purpose and was intended for future use for something like a payment channel. The solution didn't work however, and since then the field has been repurposed. It has two uses. The first is to signal 'replace by fee' (RBF). Any value less than `0xfffffffe` will signal for RBF. The second is to for use as relative time-lock. For more on this review the chapter on transaction-level and script-level timelocks."
    ]
   },
   {


### PR DESCRIPTION
the first commit has small edits to fix typos, make styling consistent, and small grammar edits to make the text easier to read

the second commit has a suggestion for rewording a section that felt difficult to parse as a reader